### PR TITLE
Define $sP8DBHost with $oP8DBHost initial value

### DIFF
--- a/migrate.php
+++ b/migrate.php
@@ -1091,6 +1091,8 @@ class P7ToP8Migration
 		{
 			$sDbPort = '';
 			$sUnixSocket = '';
+            $sP8DBHost = $oP8DBHost;
+
 			$iPos = strpos($oP8DBHost, ':');
 			if (false !== $iPos && 0 < $iPos)
 			{


### PR DESCRIPTION
Since the Aurora 8 the Admin panel doesn't require a port number for DB Host entry developers may enter hostname or ip address without a port number for that field.

In the migrate.php script, **$sP8DBHost** variable used for PDO connection string. 

It's only defined in an IF statement's body and code only will enter that IF statement when the DB HOST (**$oP8DBHost**) contains colon ( **:** ) character.

When the DB HOST (**$oP8DBHost**) doesn't contain colon character, the PDO connection string built with an undefined variable and throws an exception.
